### PR TITLE
Ts edd support

### DIFF
--- a/src/utils/getObjectPath.js
+++ b/src/utils/getObjectPath.js
@@ -14,6 +14,7 @@ function getPath(path) {
   const NE = 'NewExpression'
   const CE = 'CallExpression'
   const TSAE = 'TSAsExpression'
+  const TSEDD = 'ExportDefaultDeclaration'
 
   if (path.type === OP && path.parent.type === OE) {
     return getPath(path.parentPath)
@@ -84,6 +85,22 @@ function getPath(path) {
   }
   if (path.type === TSAE && path.parent.type === VD) {
     return path.parent.id.name
+  }
+
+  // TypeScript: export default
+  /* example
+  export default {
+    a: {
+        b: {
+            c: 1
+        }
+      }
+  }
+  */
+  if (
+    path.type === OE && path.parent.type === TSEDD
+  ) {
+    return ''
   }
 }
 

--- a/src/utils/getObjectPath.js
+++ b/src/utils/getObjectPath.js
@@ -1,6 +1,10 @@
 const parser = require('@babel/parser')
 const traverse = require('@babel/traverse').default
 
+function joinPaths(base, key) {
+  return base ? `${base}.${key}` : key
+}
+
 // eslint-disable-next-line max-statements
 function getPath(path) {
   const OP = 'ObjectProperty'
@@ -15,14 +19,14 @@ function getPath(path) {
     return getPath(path.parentPath)
   }
   if (path.type === OE && path.parent.type === OP) {
-    return getPath(path.parentPath) + '.' + path.parent.key.name
+    return joinPaths(getPath(path.parentPath), path.parent.key.name)
   }
   // Array index
   if (path.type === OE && path.parent.type === AE) {
     return `${getPath(path.parentPath)}[${path.key}]`
   }
   if (path.type === AE && path.parent.type === OP) {
-    return getPath(path.parentPath) + '.' + path.parent.key.name
+    return joinPaths(getPath(path.parentPath), path.parent.key.name)
   }
 
   // function call
@@ -109,13 +113,13 @@ module.exports = function getObjectPath(code, row, column, isFinally) {
       if (isNodeValid && isColumnInRange) {
         if (node.type === 'Identifier' && parentPath.type !== 'ObjectMethod') {
           // @ts-ignore
-          path = getPath(parentPath) + '.' + node.name
+          path = joinPaths(getPath(parentPath), node.name)
         }
 
         // @ts-ignore
         if (node.key && node.key.type === 'Identifier') {
           // @ts-ignore
-          path = getPath(parentPath) + '.' + node.key.name
+          path = joinPaths(getPath(parentPath), node.key.name)
         }
 
         /* example

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -22,11 +22,11 @@ suite('getObjectPath', () => {
     }
     {
       const res = 'test_obj.a.bb'
-      assert.strictEqual(res, getObjectPath(code, 8,20))
+      assert.strictEqual(res, getObjectPath(code, 8, 20))
     }
     {
       const res = 'test_obj.a.bb.fun'
-      assert.strictEqual(res, getObjectPath(code, 9,10))
+      assert.strictEqual(res, getObjectPath(code, 9, 10))
     }
   })
   test('function test', () => {
@@ -48,5 +48,9 @@ suite('getObjectPath', () => {
       const res = 'test_proxy.get'
       assert.strictEqual(res, getObjectPath(code, 21, 7))
     }
+  })
+  test('export default declarations', () => {
+    const res = 'a.b.c'
+    assert.strictEqual(res, getObjectPath(code, 29))
   })
 })

--- a/test/template.txt
+++ b/test/template.txt
@@ -23,3 +23,10 @@ const test_proxy = new Proxy(
     }
   }
 )
+export default {
+  a: {
+      b: {
+          c: 1
+      }
+    }
+}


### PR DESCRIPTION
Adds support for TypeScript export default declarations

```ts
  export default {
    a: {
        b: {
            c: 1
        }
      }
  }
```

Since I have introduced a `joinPaths` function that omit empty paths, this will not put any `undefined` terms into any paths anymore. So this might also 'fix' other cases.

I was not sure how to add any test cases, so I didn't 😉 